### PR TITLE
Get repos: allow recursive api call when repos > 50 (paginated limit)

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -22,15 +22,21 @@ function api(endpoint, method) {
         .set('X-Api-Token', config.token);
 }
 
-function getRepositories(cb) {
-    api('repositories').end(function (err, res) {
+function getRepositories(cb, uri = 'repositories', carry = {entries:[]}) {
+    api(uri).end(function (err, res) {
         if (err) {
             reportError(err);
         }
 
-        cb(res.body);
+        if (! res.body.meta.next_uri) {
+            return cb(mergedEntries(res.body.entries, carry.entries));
+        }
+
+        return getRepositories(cb, res.body.meta.next_uri, mergedEntries(res.body.entries, carry.entries));
     });
 }
+
+const mergedEntries = (a, b) => ({entries: [...a, ...b]})
 
 function repo(name, cb) {
     logger.spin('Fetching repos, please wait ...');


### PR DESCRIPTION
In lib/api.js
The getRepositories() method only returns 50 repositories max because according to deploybot API doc:
https://deploybot.com/api/repositories#list-repositories

There is a default and max limit of 50 repos per request.

This PR allows for recursively calling the meta/next_uri if provided, thus fetching all subsequent repositories